### PR TITLE
Encryption with full secrecy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ miniscript = "12.3.2"
 sha2 = "0.10.9"
 clap = { version = "4.4", features = ["derive"] }
 base64 = "0.21"
+itertools = "0.14.0"
 
 [dev-dependencies]
 rand = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The core logic of `descriptor-encrypt` can also be used as a library in other Ru
 **`encrypt_with_full_secrecy(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>>`**
 
 * Identical to `encrypt` except it leaks no information about key inclusion without full decryption.
-* Provides maximum privacy but slower to decrypt, as we must try all possible combinations of shares and keys. This has a running time of $O((N+1)^K)$, where $N$ is the number of provided public keys and $K$ is the number of shares.
+* Provides maximum privacy but slower to decrypt, as we must try all possible combinations of shares and keys. This has a running time of $O((N+1)^K)$, where $N$ is the number of provided keys and $K$ is the number of shares.
 
 **`decrypt(data: &[u8], pks: Vec<DescriptorPublicKey>) -> Result<Descriptor<DescriptorPublicKey>>`**
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The executable will be located at `target/release/descriptor-encrypt`.
     **Arguments**:
     *   `<DESCRIPTOR_STRING>`: The Bitcoin descriptor string to encrypt.
 
+    **Options**:
+    *   `-w, --with-full-secrecy`: Enable full secrecy mode, which leaks no information about key inclusion without full decryption.
+
 *   #### Decrypt a Descriptor
     Decrypts Base64-encoded encrypted descriptor data using a set of public keys.
     ```bash
@@ -91,6 +94,11 @@ The core logic of `descriptor-encrypt` can also be used as a library in other Ru
 **`encrypt(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>>`**
     
 * Encrypts a descriptor such that it can only be recovered by a set of keys with access to the funds.
+
+**`encrypt_with_full_secrecy(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>>`**
+
+* Identical to `encrypt` except it leaks no information about key inclusion without full decryption.
+* Provides maximum privacy but slower to decrypt, as we must try all possible combinations of shares and keys. This has a running time of $O((N+1)^K)$, where $N$ is the number of provided public keys and $K$ is the number of shares.
 
 **`decrypt(data: &[u8], pks: Vec<DescriptorPublicKey>) -> Result<Descriptor<DescriptorPublicKey>>`**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ pub fn encrypt(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
     // Encrypt payload and shard encryption key into encrypted shares (1 per key)
     let nonce = [0u8; 12];
     let (encrypted_shares, encrypted_payload) =
-        payload::encrypt_payload_and_shard_key(desc, encryption_key.into(), nonce, payload)?;
+        payload::encrypt_with_authenticated_shards(desc, encryption_key.into(), nonce, payload)?;
 
     Ok([
         vec![V0],
@@ -189,7 +189,7 @@ pub fn decrypt(
     let encrypted_payload = &data[size + num_keys * 48..];
 
     let nonce = [0u8; 12];
-    let payload = payload::recover_key_and_decrypt_payload(
+    let payload = payload::decrypt_with_authenticated_shards(
         template.clone(),
         encrypted_shares,
         pks,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub fn encrypt(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
 }
 
 /// Identical to `encrypt` except it provides full secrecy during encryption. as no
-/// information is gained unless the descriptor can be decrypted.
+/// information is gained about key inclusion unless the descriptor can be decrypted.
 ///
 /// Tradeoffs:
 /// - More private: no information is revealed from partial decryptions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,9 @@ mod tests {
 
             let keys = desc.clone().to_tree().extract_keys();
             let ciphertext = encrypt(desc.clone()).unwrap();
+            assert_eq!(desc, decrypt(&ciphertext, keys.clone()).unwrap());
+
+            let ciphertext = encrypt_with_full_secrecy(desc.clone()).unwrap();
             assert_eq!(desc, decrypt(&ciphertext, keys).unwrap());
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,11 +132,27 @@ use sha2::{Digest, Sha256};
 
 use crate::payload::ToDescriptorTree;
 
-const V0: u8 = 0u8;
+const V0: u8 = 0;
+const V1: u8 = 1;
 
 /// Encrypts a descriptor such that it can only be recovered by a set of
 /// keys with access to the funds.
 pub fn encrypt(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
+    encrypt_with_version(V0, desc)
+}
+
+/// Identical to `encrypt` except it provides full secrecy during encryption. as no
+/// information is gained unless the descriptor can be decrypted.
+///
+/// Tradeoffs:
+/// - More private: no information is revealed from partial decryptions
+/// - Slower to decrypt: must try all possible combinations of keys. This is O((N+1)^K),
+///  where N is the number of keys and K is the number of shares.
+pub fn encrypt_with_full_secrecy(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
+    encrypt_with_version(V1, desc)
+}
+
+fn encrypt_with_version(version: u8, desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
     let (template, payload) = template::encode(desc.clone());
 
     // Deterministically derive encryption key
@@ -147,11 +163,16 @@ pub fn encrypt(desc: Descriptor<DescriptorPublicKey>) -> Result<Vec<u8>> {
 
     // Encrypt payload and shard encryption key into encrypted shares (1 per key)
     let nonce = [0u8; 12];
-    let (encrypted_shares, encrypted_payload) =
-        payload::encrypt_with_authenticated_shards(desc, encryption_key.into(), nonce, payload)?;
+    let (encrypted_shares, encrypted_payload) = match version {
+        V0 => {
+            payload::encrypt_with_authenticated_shards(desc, encryption_key.into(), nonce, payload)?
+        }
+        V1 => payload::encrypt_with_full_secrecy(desc, encryption_key.into(), nonce, payload)?,
+        _ => return Err(anyhow!("Unsupported version: {}", version)),
+    };
 
     Ok([
-        vec![V0],
+        vec![version],
         template,
         encrypted_shares.concat(),
         encrypted_payload,
@@ -168,9 +189,10 @@ pub fn decrypt(
         return Err(anyhow!("Empty data"));
     }
 
-    let data = match data[0] {
-        V0 => &data[1..],
-        _ => return Err(anyhow!("Unsupported version: {}", data[0])),
+    let version = data[0];
+    let data = match version {
+        V0 | V1 => &data[1..],
+        _ => return Err(anyhow!("Unsupported version: {}", version)),
     };
 
     let (template, size) = template::decode(data)?;
@@ -189,13 +211,23 @@ pub fn decrypt(
     let encrypted_payload = &data[size + num_keys * 48..];
 
     let nonce = [0u8; 12];
-    let payload = payload::decrypt_with_authenticated_shards(
-        template.clone(),
-        encrypted_shares,
-        pks,
-        nonce,
-        encrypted_payload.to_vec(),
-    )?;
+    let payload = match version {
+        V0 => payload::decrypt_with_authenticated_shards(
+            template.clone(),
+            encrypted_shares,
+            pks,
+            nonce,
+            encrypted_payload.to_vec(),
+        )?,
+        V1 => payload::decrypt_with_full_secrecy(
+            template.clone(),
+            encrypted_shares,
+            pks,
+            nonce,
+            encrypted_payload.to_vec(),
+        )?,
+        _ => unreachable!("unsupported version"),
+    };
 
     let desc = template::decode_with_payload(data, &payload)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,8 +190,9 @@ pub fn decrypt(
     }
 
     let version = data[0];
-    let data = match version {
-        V0 | V1 => &data[1..],
+    let (data, share_size) = match version {
+        V0 => (&data[1..], 48_usize),
+        V1 => (&data[1..], 32_usize),
         _ => return Err(anyhow!("Unsupported version: {}", version)),
     };
 
@@ -203,12 +204,12 @@ pub fn decrypt(
         return Err(anyhow!("Missing bytes"));
     }
 
-    let encrypted_shares: Vec<Vec<u8>> = data[size..size + num_keys * 48]
-        .chunks_exact(48)
+    let encrypted_shares: Vec<Vec<u8>> = data[size..size + num_keys * share_size]
+        .chunks_exact(share_size)
         .map(|chunk| chunk.to_vec())
         .collect();
 
-    let encrypted_payload = &data[size + num_keys * 48..];
+    let encrypted_payload = &data[size + num_keys * share_size..];
 
     let nonce = [0u8; 12];
     let payload = match version {

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,8 @@ fn handle_encrypt(args: EncryptArgs) -> Result<()> {
         .context("Failed to parse descriptor string")?;
 
     let encrypted_data = if args.with_full_secrecy {
-        descriptor_encrypt::encrypt_with_full_secrecy(desc).context("Encryption with full secrecy failed")?
+        descriptor_encrypt::encrypt_with_full_secrecy(desc)
+            .context("Encryption with full secrecy failed")?
     } else {
         descriptor_encrypt::encrypt(desc).context("Encryption failed")?
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Encrypts a Bitcoin descriptor, outputs Base64
+    /// Encrypts a Bitcoin descriptor, outputs Base64 (use -w or --with-full-secrecy for maximum privacy)
     Encrypt(EncryptArgs),
     /// Decrypts a Base64-encoded encrypted descriptor
     Decrypt(DecryptArgs),
@@ -35,6 +35,9 @@ enum Commands {
 struct EncryptArgs {
     /// The Bitcoin descriptor string to encrypt
     descriptor: String,
+    /// Enable full secrecy mode, which leaks no information about partial decryptions
+    #[clap(short, long)]
+    with_full_secrecy: bool,
 }
 
 #[derive(Args)]
@@ -74,7 +77,11 @@ fn handle_encrypt(args: EncryptArgs) -> Result<()> {
     let desc = Descriptor::<DescriptorPublicKey>::from_str(&args.descriptor)
         .context("Failed to parse descriptor string")?;
 
-    let encrypted_data = descriptor_encrypt::encrypt(desc).context("Encryption failed")?;
+    let encrypted_data = if args.with_full_secrecy {
+        descriptor_encrypt::encrypt_with_full_secrecy(desc).context("Encryption with full secrecy failed")?
+    } else {
+        descriptor_encrypt::encrypt(desc).context("Encryption failed")?
+    };
 
     println!("{}", BASE64_STANDARD.encode(encrypted_data));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ enum Commands {
 struct EncryptArgs {
     /// The Bitcoin descriptor string to encrypt
     descriptor: String,
-    /// Enable full secrecy mode, which leaks no information about partial decryptions
+    /// Enable full secrecy mode, which leaks no information about key inclusion without full decryption.
     #[clap(short, long)]
     with_full_secrecy: bool,
 }

--- a/src/payload/encrypt.rs
+++ b/src/payload/encrypt.rs
@@ -130,9 +130,14 @@ pub fn decrypt_with_full_secrecy(
     let cipher = UnauthenticatedCipher {};
     let num_slots = encrypted_shares.len();
 
+    // Deduplicate public keys
+    let mut unique_keys = public_keys.clone();
+    unique_keys.sort();
+    unique_keys.dedup();
+
     // Each slot can hold any one of the provided public keys or None.
     let mut choices_for_each_slot: Vec<Option<&DescriptorPublicKey>> =
-        public_keys.iter().map(Some).collect();
+        unique_keys.iter().map(Some).collect();
     choices_for_each_slot.push(None);
 
     // Create an iterator that will produce all combinations.

--- a/src/payload/encrypt.rs
+++ b/src/payload/encrypt.rs
@@ -154,7 +154,7 @@ pub fn decrypt_with_full_secrecy(
         }
     }
 
-    Err(Error::NoSuitableCombination.into())
+    Err(Error::DecryptionFailed.into())
 }
 
 fn encrypt_with_cipher<T: KeyCipher>(
@@ -367,7 +367,7 @@ pub enum Error {
     /// Additional keys required to decrypt
     KeysRequired(usize),
     /// Unable to decrypt with any combination of keys
-    NoSuitableCombination,
+    DecryptionFailed,
 }
 
 impl std::fmt::Display for Error {
@@ -380,8 +380,8 @@ impl std::fmt::Display for Error {
             Self::KeysRequired(num_required) => {
                 write!(f, "requires {num_required} additional key(s)")
             }
-            Self::NoSuitableCombination => {
-                write!(f, "unable to decrypt with any combination of keys")
+            Self::DecryptionFailed => {
+                write!(f, "unable to decrypt")
             }
         }
     }

--- a/src/payload/encrypt.rs
+++ b/src/payload/encrypt.rs
@@ -107,8 +107,9 @@ pub fn decrypt_with_authenticated_shards(
         Error::TooManyShares
     }
 
+    let pks = public_keys.iter().map(|pk| Some(pk)).collect();
     let cipher = AuthenticatedCipher {};
-    tree.decrypt(public_keys, nonce, ciphertext, &cipher)
+    tree.decrypt(pks, nonce, ciphertext, &cipher)
 }
 
 impl ShamirTree {
@@ -187,7 +188,7 @@ impl ShamirTree {
     /// Decrypts ciphertext reassembling the master secret using a list of public keys
     fn decrypt<T: KeyCipher>(
         &self,
-        keys: Vec<DescriptorPublicKey>,
+        keys: Vec<Option<&DescriptorPublicKey>>,
         nonce: Nonce,
         ciphertext: Data,
         cipher: &T,
@@ -218,7 +219,7 @@ impl ShamirTree {
     /// Helper function to decrypt tree of encrypted shamir shares
     fn decrypt_tree<T: KeyCipher>(
         &self,
-        keys: &Vec<DescriptorPublicKey>,
+        keys: &Vec<Option<&DescriptorPublicKey>>,
         hash: &[u8; 32],
         cipher: &T,
         leaf_index: &mut usize,


### PR DESCRIPTION
This PR adds the library function `encrypt_with_full_secrecy` and the command line option `--with-full-secrecy` to `encrypt`.

Encrypting with full secrecy operates identically to normal encryption, except it leaks no information about the inclusion of a key unless enough keys are present to fully decrypt the descriptor. This provides maximum privacy and is ideal for use cases involving an encrypted descriptor stored in public (ex: on Bitcoin).

With normal encryption, an attacker that gains access to one key learns no information about the contents of the descriptor, but they learn that the key is part of a multisig and therefore potentially valuable.

With full secrecy, an attacker would gain no information about the existence of the multisig without compromising enough keys to spend the funds.

### How it works

With normal encryption, shares are encrypted using an authenticated cipher (ChaCha20-Poly1305) and the payload is encrypted using an unauthenticated cipher (ChaCha20).

In contrast, with full secrecy, shares are encrypted using ChaCha20, and the payload is encrypted using ChaCha20-Poly1305. Therefore, no information is gained unless the payload can be decrypted.

The primary tradeoff with full secrecy is that it becomes slower to decrypt. To decrypt, we must try all possible combinations of shares and keys. Each share is matched with either one of the keys or no key, in which case it is not used for decryption.

This has a running time of $O((N+1)^K)$, where $N$ is the number of keys and $K$ is the number of shares. This makes it slower than normal encryption for large descriptors with many keys, but reasonably fast for typical descriptors involving only a couple keys.